### PR TITLE
Fix CPU hogs.

### DIFF
--- a/ckanext/iotrans/iotrans.py
+++ b/ckanext/iotrans/iotrans.py
@@ -260,16 +260,14 @@ def to_file(context, data_dict):
                             driver=drivers[target_format],
                             crs=from_epsg(target_epsg),
                         ) as outlayer:
-                            outlayer.writerecords(
-                                utils.dump_to_geospatial_generator(
-                                    dump_filepath,
-                                    fieldnames,
-                                    target_format,
-                                    data_dict["source_epsg"],
-                                    target_epsg,
-                                )
-                            )
-                            outlayer.close()
+                            for feature in utils.dump_to_geospatial_generator(
+                                dump_filepath,
+                                fieldnames,
+                                target_format,
+                                data_dict["source_epsg"],
+                                target_epsg,
+                            ):
+                                outlayer.write(feature)
 
                     elif target_format.lower() == "shp":
                         # Shapefiles are special
@@ -314,17 +312,15 @@ def to_file(context, data_dict):
                             driver=drivers[target_format],
                             crs=from_epsg(target_epsg),
                         ) as outlayer:
-                            outlayer.writerecords(
-                                utils.dump_to_geospatial_generator(
-                                    dump_filepath,
-                                    fieldnames,
-                                    target_format,
-                                    data_dict["source_epsg"],
-                                    target_epsg,
-                                    col_map
-                                )
-                            )
-                            outlayer.close()
+                            for feature in utils.dump_to_geospatial_generator(
+                                dump_filepath,
+                                fieldnames,
+                                target_format,
+                                data_dict["source_epsg"],
+                                target_epsg,
+                                col_map,
+                            ):
+                                outlayer.write(feature)
 
                         output_filepath = utils.write_to_zipped_shapefile(
                             fieldnames, dir_path,


### PR DESCRIPTION
This PR fixes issues with data cache processes that consume a large amount of CPU resources.

One of the critical points we discovered is that Fiona consumes a lot of memory. So the pr is mostly around that area.

Additionally, we noticed that in your DAG (https://github.com/open-data-toronto/operations), you are directly calling datastore_cache. It would be better to use the datapusher_submit API instead. This approach ensures that Datapusher handles the API call, which is beneficial for asynchronous operations and prevents blocking other CKAN operations. You can find more details about the API here: [datapusher_submit implementation](https://github.com/ckan/ckan/blob/4d5c4f697f97c39d7549a83f7193b1bf4eedc16e/ckanext/datapusher/logic/action.py#L29).

Lastly, I noticed some errors occurring during datastore operations. While these errors don’t significantly affect the system, I’d like to confirm if you are also encountering them on your end. Below are the details of the error log:
```
 [ckan.views.api] Validation error (Action API): '{\'fields\': [\'"_id" is not a valid field name\'], \'__type\': \'Validation Error\'}'
ckan-1          | 2024-11-18 15:59:30,461 INFO  [ckan.config.middleware.flask_app]  409 /api/3/action/datastore_create render time 0.073 seconds
```

Finally, while testing on your end, it would be helpful if you had a large enough CSV file to fully replicate the crash on our end.