### PR TITLE
add background jobs and copy data from datastore to csv

### DIFF
--- a/ckanext/iotrans/iotrans.py
+++ b/ckanext/iotrans/iotrans.py
@@ -21,107 +21,20 @@ from .utils.to_file import (
     non_spatial_to_file_factory,
     spatial_to_file_factory,
 )
-
+from ckan.lib.jobs import enqueue
+from ckan.plugins.toolkit import enqueue_job
+from ckanext.iotrans.utils.process import process_to_file
 
 @tk.side_effect_free
 def to_file(context, data_dict):
     """
-    inputs:
-        resource_id: CKAN datastore resource ID
-        source_epsg: source EPSG of resource ID, if data is spatial
-        target_epsgs: list of desired EPSGs of output files, if data is spatial
-        target_formats: list of desired file formats
-
-    a spatial datasets needs a geometry column
-    assumes geometry column in dataset contains geometry
-    assumes geometry objects within a dataset are all the same geometry type
-        ex: (all Point, all Line, or all Polygon)
-
-    outputs:
-        writes desired files to folder in /tmp
-        returns a list of filepaths, where the outputs are stored on disk
+    Enqueue a background job to process the `to_file` task.
     """
-    is_spatial = True
-    try:
-        data = ToFileParamsSpatial(**data_dict)
-    except ValidationError as spatial_error:
-        try:
-            data = ToFileParamsNonSpatial(**data_dict)
-            is_spatial = False
-        except ValidationError as non_spatial_error:
-            raise tk.ValidationError(
-                {
-                    "constraints": [
-                        f"Could not parse spatial-type params: {spatial_error}",
-                        f"Could not parse non-spatial-type params: {non_spatial_error}",
-                    ]
-                }
-            ) from spatial_error
-
-    # Make sure the resource id provided is for a datastore resource
-    resource_metadata = tk.get_action("resource_show")(
-        context, {"id": data.resource_id}
-    )
-    if generic.is_falsey(resource_metadata.get("datastore_active", None)):
-        raise tk.ValidationError(
-            {"constraints": [f"{data.resource_id} is not a datastore resource!"]}
-        )
-
-    datastore_resource = tk.get_action("datastore_search")(
-        context, {"resource_id": data.resource_id}
-    )
-    if len(datastore_resource["records"]) < 1:
-        raise tk.ValidationError(
-            {"constraints": [f"Datastore resource {data.resource_id} is empty"]}
-        )
-
-    # Download all rows to a local csv in a temporary directory. Effictively a local
-    # cache on disk. 2 reasons:
-    # 1. We can't hold files this large in memory typically
-    # 2. We need to re-use these data multiple times; we can at least limit db queries
-    #    to a constant rathern than N times (where N is the number of outputs we target)
-    temp_dir = tempfile.mkdtemp(dir=config.get("ckan.storage_path"))
-    dump_filepath = generic.get_filepath(
-        temp_dir,
-        resource_metadata["name"],
-        data_dict.get("source_epsg", None),
-        "jsonlines",
-    )
-    generator = generic.dump_generator(data.resource_id, context)
-    json_lines.write_to_jsonlines(dump_filepath, generator)
-
-    geometry_type = (
-        json.loads(datastore_resource["records"][0]["geometry"])["type"]
-        if is_spatial
-        else None
-    )
-    datastore_metadata: DatastoreResourceMetadata = {
-        "fields": datastore_resource["fields"],
-        "geometry_type": geometry_type,
-        "name": resource_metadata["name"],
-    }
-
-    # Depending on whether spatial or not, select a factory method that will generate
-    # all the output 'handlers'. 1 'handler' = 1 output file. Both handlers and handler
-    # factories should have the same type signatures respectively
-    handler_factory: Callable = (
-        spatial_to_file_factory if is_spatial else non_spatial_to_file_factory
-    )
-    out_dir = os.path.join(temp_dir, "output")
-    os.makedirs(out_dir)
-    handlers: List[ToFileHandler] = handler_factory(
-        params=data,
-        out_dir=out_dir,
-        datastore_metadata=datastore_metadata,
-    )
-
-    # Iterate through handlers produced by the factory. For each we run to_file
-    output = {}
-    for handler in handlers:
-        with open(dump_filepath, "r") as json_lines_file:
-            row_generator = json_lines.jsonlines_reader(json_lines_file)
-            output[handler.name()] = handler.to_file(row_generator)
-    return output
+    job = enqueue_job(process_to_file, [context, 
+                                        data_dict],
+                                        title=f"To_file trannsformtion-{data_dict.get('resource_id')}",
+                                        rq_kwargs={"timeout": 18000})
+    return {"job_id": job.id, "status": "queued"}
 
 
 @tk.side_effect_free

--- a/ckanext/iotrans/iotrans.py
+++ b/ckanext/iotrans/iotrans.py
@@ -25,15 +25,18 @@ from ckan.lib.jobs import enqueue
 from ckan.plugins.toolkit import enqueue_job
 from ckanext.iotrans.utils.process import process_to_file
 
+
 @tk.side_effect_free
 def to_file(context, data_dict):
     """
     Enqueue a background job to process the `to_file` task.
     """
-    job = enqueue_job(process_to_file, [context, 
-                                        data_dict],
-                                        title=f"To_file trannsformtion-{data_dict.get('resource_id')}",
-                                        rq_kwargs={"timeout": 18000})
+    job = enqueue_job(
+        process_to_file,
+        [context, data_dict],
+        title=f"To_file trannsformtion-{data_dict.get('resource_id')}",
+        rq_kwargs={"timeout": 18000},
+    )
     return {"job_id": job.id, "status": "queued"}
 
 

--- a/ckanext/iotrans/plugin.py
+++ b/ckanext/iotrans/plugin.py
@@ -18,6 +18,31 @@ class IotransPlugin(plugins.SingletonPlugin):
     """
 
     plugins.implements(plugins.IActions)
+    plugins.implements(plugins.IClick)
+
+    def get_commands(self):
+        import click
+        @click.command()
+        @click.argument('resourceid')
+        @click.argument('targetformat')
+        def ioprofile(resourceid, targetformat):
+
+            data = {
+                "resource_id": resourceid,
+                "source_epsg": 4326,
+                "target_epsgs": [2952],
+                "target_formats": targetformat.strip().split(","),
+            }
+           
+            try:
+                result = iotrans.to_file({"ignore_auth": True}, data)
+                click.echo(click.style(str(result), fg="green"))
+            except Exception as e:
+                click.echo(click.style("❌ An error occurred during the operation:", fg="red", bold=True))
+                click.echo(click.style(str(e), fg="red"))
+                return
+
+        return [ioprofile]
 
     def get_actions(self):
         return {

--- a/ckanext/iotrans/plugin.py
+++ b/ckanext/iotrans/plugin.py
@@ -25,7 +25,7 @@ class IotransPlugin(plugins.SingletonPlugin):
         @click.command()
         @click.argument('resourceid')
         @click.argument('targetformat')
-        def ioprofile(resourceid, targetformat):
+        def tofile(resourceid, targetformat):
 
             data = {
                 "resource_id": resourceid,
@@ -42,7 +42,7 @@ class IotransPlugin(plugins.SingletonPlugin):
                 click.echo(click.style(str(e), fg="red"))
                 return
 
-        return [ioprofile]
+        return [tofile]
 
     def get_actions(self):
         return {

--- a/ckanext/iotrans/plugin.py
+++ b/ckanext/iotrans/plugin.py
@@ -22,9 +22,10 @@ class IotransPlugin(plugins.SingletonPlugin):
 
     def get_commands(self):
         import click
+
         @click.command()
-        @click.argument('resourceid')
-        @click.argument('targetformat')
+        @click.argument("resourceid")
+        @click.argument("targetformat")
         def tofile(resourceid, targetformat):
 
             data = {
@@ -33,12 +34,18 @@ class IotransPlugin(plugins.SingletonPlugin):
                 "target_epsgs": [2952],
                 "target_formats": targetformat.strip().split(","),
             }
-           
+
             try:
                 result = iotrans.to_file({"ignore_auth": True}, data)
                 click.echo(click.style(str(result), fg="green"))
             except Exception as e:
-                click.echo(click.style("❌ An error occurred during the operation:", fg="red", bold=True))
+                click.echo(
+                    click.style(
+                        "❌ An error occurred during the operation:",
+                        fg="red",
+                        bold=True,
+                    )
+                )
                 click.echo(click.style(str(e), fg="red"))
                 return
 

--- a/ckanext/iotrans/utils/json_lines.py
+++ b/ckanext/iotrans/utils/json_lines.py
@@ -1,5 +1,20 @@
 import json
 from typing import Dict, Generator, Iterable
+import psycopg2
+from ckan.common import config
+
+def dump_table_to_csv(resource_id: str, output_file: str) -> None:
+    """Dumps a CKAN datastore table to a CSV file using PostgreSQL's COPY command."""
+    datastore_url = config.get(u'ckan.datastore.read_url')
+    query = f"COPY \"{resource_id}\" TO STDOUT WITH CSV HEADER"
+
+    with psycopg2.connect(datastore_url) as conn, open(output_file, "w", encoding="utf-8") as f:
+        cursor = conn.cursor()
+        cursor.copy_expert(query, f)  # Writes full table to file
+        cursor.close()
+
+  
+
 
 
 def write_to_jsonlines(dump_filepath: str, rows: Iterable) -> None:

--- a/ckanext/iotrans/utils/process.py
+++ b/ckanext/iotrans/utils/process.py
@@ -21,22 +21,6 @@ from .to_file import (
 )
 
 
-def process_to_file2(context, data_dict):
-    log = logging.getLogger(__name__)
-    log.info("Starting the background job for processing to file.")
-    log.info("Context: %s", context)
-    log.info("Data Dictionary: %s", data_dict)
-    try:
-        # Simulate a delay
-        time.sleep(120)  # Sleep for 2 minutes
-        
-        log.info("Successfully processed the file.")
-        return {"status": "success"}
-    except Exception as e:
-        log.error("Error processing the file: %s", str(e))
-        return {"status": "error", "message": str(e)}
-    
-
     
 def process_to_file(context, data_dict):
     """

--- a/ckanext/iotrans/utils/process.py
+++ b/ckanext/iotrans/utils/process.py
@@ -21,7 +21,6 @@ from .to_file import (
 )
 
 
-    
 def process_to_file(context, data_dict):
     """
     inputs:
@@ -87,14 +86,15 @@ def process_to_file(context, data_dict):
         data_dict.get("source_epsg", None),
         "jsonlines",
     )
-    
-    json_lines.dump_table_to_csv(data.resource_id, dump_filepath)
+    generator = json_lines.dump_table_to_jsonlines(data.resource_id)
+    json_lines.write_to_jsonlines(dump_filepath, generator)
 
     geometry_type = (
         json.loads(datastore_resource["records"][0]["geometry"])["type"]
         if is_spatial
         else None
     )
+
     datastore_metadata: DatastoreResourceMetadata = {
         "fields": datastore_resource["fields"],
         "geometry_type": geometry_type,

--- a/ckanext/iotrans/utils/process.py
+++ b/ckanext/iotrans/utils/process.py
@@ -1,0 +1,140 @@
+import time
+import logging
+import json
+import logging
+import os
+import tempfile
+from typing import Callable, List
+
+import ckan.plugins.toolkit as tk
+from ckan.common import config
+from pydantic import ValidationError
+
+from . import generic, json_lines
+from .to_file import (
+    DatastoreResourceMetadata,
+    ToFileHandler,
+    ToFileParamsNonSpatial,
+    ToFileParamsSpatial,
+    non_spatial_to_file_factory,
+    spatial_to_file_factory,
+)
+
+
+def process_to_file2(context, data_dict):
+    log = logging.getLogger(__name__)
+    log.info("Starting the background job for processing to file.")
+    log.info("Context: %s", context)
+    log.info("Data Dictionary: %s", data_dict)
+    try:
+        # Simulate a delay
+        time.sleep(120)  # Sleep for 2 minutes
+        
+        log.info("Successfully processed the file.")
+        return {"status": "success"}
+    except Exception as e:
+        log.error("Error processing the file: %s", str(e))
+        return {"status": "error", "message": str(e)}
+    
+
+    
+def process_to_file(context, data_dict):
+    """
+    inputs:
+        resource_id: CKAN datastore resource ID
+        source_epsg: source EPSG of resource ID, if data is spatial
+        target_epsgs: list of desired EPSGs of output files, if data is spatial
+        target_formats: list of desired file formats
+
+    a spatial datasets needs a geometry column
+    assumes geometry column in dataset contains geometry
+    assumes geometry objects within a dataset are all the same geometry type
+        ex: (all Point, all Line, or all Polygon)
+
+    outputs:
+        writes desired files to folder in /tmp
+        returns a list of filepaths, where the outputs are stored on disk
+    """
+    log = logging.getLogger(__name__)
+    log.info("Starting the background job for to_file process.")
+    is_spatial = True
+    try:
+        data = ToFileParamsSpatial(**data_dict)
+    except ValidationError as spatial_error:
+        try:
+            data = ToFileParamsNonSpatial(**data_dict)
+            is_spatial = False
+        except ValidationError as non_spatial_error:
+            raise tk.ValidationError(
+                {
+                    "constraints": [
+                        f"Could not parse spatial-type params: {spatial_error}",
+                        f"Could not parse non-spatial-type params: {non_spatial_error}",
+                    ]
+                }
+            ) from spatial_error
+
+    # Make sure the resource id provided is for a datastore resource
+    resource_metadata = tk.get_action("resource_show")(
+        context, {"id": data.resource_id}
+    )
+    if generic.is_falsey(resource_metadata.get("datastore_active", None)):
+        raise tk.ValidationError(
+            {"constraints": [f"{data.resource_id} is not a datastore resource!"]}
+        )
+
+    datastore_resource = tk.get_action("datastore_search")(
+        context, {"resource_id": data.resource_id}
+    )
+    if len(datastore_resource["records"]) < 1:
+        raise tk.ValidationError(
+            {"constraints": [f"Datastore resource {data.resource_id} is empty"]}
+        )
+
+    # Download all rows to a local csv in a temporary directory. Effictively a local
+    # cache on disk. 2 reasons:
+    # 1. We can't hold files this large in memory typically
+    # 2. We need to re-use these data multiple times; we can at least limit db queries
+    #    to a constant rathern than N times (where N is the number of outputs we target)
+    temp_dir = tempfile.mkdtemp(dir=config.get("ckan.storage_path"))
+    dump_filepath = generic.get_filepath(
+        temp_dir,
+        resource_metadata["name"],
+        data_dict.get("source_epsg", None),
+        "jsonlines",
+    )
+    
+    json_lines.dump_table_to_csv(data.resource_id, dump_filepath)
+
+    geometry_type = (
+        json.loads(datastore_resource["records"][0]["geometry"])["type"]
+        if is_spatial
+        else None
+    )
+    datastore_metadata: DatastoreResourceMetadata = {
+        "fields": datastore_resource["fields"],
+        "geometry_type": geometry_type,
+        "name": resource_metadata["name"],
+    }
+
+    # Depending on whether spatial or not, select a factory method that will generate
+    # all the output 'handlers'. 1 'handler' = 1 output file. Both handlers and handler
+    # factories should have the same type signatures respectively
+    handler_factory: Callable = (
+        spatial_to_file_factory if is_spatial else non_spatial_to_file_factory
+    )
+    out_dir = os.path.join(temp_dir, "output")
+    os.makedirs(out_dir)
+    handlers: List[ToFileHandler] = handler_factory(
+        params=data,
+        out_dir=out_dir,
+        datastore_metadata=datastore_metadata,
+    )
+
+    # Iterate through handlers produced by the factory. For each we run to_file
+    output = {}
+    for handler in handlers:
+        with open(dump_filepath, "r") as json_lines_file:
+            row_generator = json_lines.jsonlines_reader(json_lines_file)
+            output[handler.name()] = handler.to_file(row_generator)
+    return output


### PR DESCRIPTION
This pr update to_file api to initiate the background job and also update the function to dump datastore data into jsonline file

## Note 

The to_file can either be intimated via API call or via terminal

```
ckan -c production.ini tofile <resource_id> <target_format>
```

and here is a  full documentation on background job and supervisor https://docs.ckan.org/en/2.9/maintaining/background-tasks.html?highlight=supervisor

and for the 3rd action which we agreed not to do, can you check this work(https://github.com/wri/wri-odp/tree/prod/prefect-server/jobs/datapusher) we did for one of our clients around using the prefect server to enable upload and download  from datastore, maybe this might clarify your ideas better
